### PR TITLE
[GitHub] 创建 issue 模板，分类 issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,83 @@
+name: Bug 反馈
+description: 反馈一个 Bug
+labels: [ "bug" ]
+title: "[BUG] "
+body:
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: 检查清单
+      description: 确保我们的错误报告表单适合您。
+      options:
+        - label: 之前没有人提交过类似或相同的 bug report。
+          required: true
+        - label: 我正在使用本软件的最新版本。
+          required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: my-ty 版本
+      description: 请选择正在使用的版本
+      options:
+        - 最新稳定版
+        - 最新 CI 版
+    validations:
+      required: true
+  - type: textarea
+    id: bug
+    attributes:
+      label: Bug 描述
+      description: 请描述 bug 详情
+      placeholder: |
+        e.g. Crashed when generating snapshot.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 预期行为
+      description: 你预期会发生什么？
+      placeholder: |
+        e.g. A New snapshot!
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 反而发生了什么？
+      placeholder: |
+        e.g. Crashed.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤
+      description: 如何复现这个 bug。
+      placeholder: |
+        1. Open the app
+        2. Crashed
+
+        What an app.
+  - type: input
+    id: ui
+    attributes:
+      label: UI / OS
+      description: 你的电视系统 UI 或 OS 或 品牌
+      placeholder: TCL / XIAOMI / PHONE / etc.
+    validations:
+      required: true
+  - type: input
+    id: android
+    attributes:
+      label: Android 版本
+      description: 你的 Android 版本
+      placeholder: "12"
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: 额外信息
+      description: 任何你觉得值得说的。

--- a/.github/ISSUE_TEMPLATE/fr.yml
+++ b/.github/ISSUE_TEMPLATE/fr.yml
@@ -1,0 +1,36 @@
+name: 功能(新频道)请求
+description: 提出一个建议
+labels: [ "enhancement" ]
+title: "[FR] "
+body:
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: 检查清单
+      description: 确保我们的错误报告表单适合您。
+      options:
+        - label: 之前没有人提交过类似或相同的功能请求。
+          required: true
+        - label: 这个建议不会背离 LibChecker 的初衷。
+          required: true
+  - type: textarea
+    id: propose
+    attributes:
+      label: 改进目的
+      description: 改进有什么用
+      placeholder: |
+        Show your idea here.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: 解决方案
+      description: 你会怎么完成这个改进？
+      placeholder: |
+        How to do it on your opinion? Or left this blank
+  - type: textarea
+    id: addition
+    attributes:
+      label: 额外信息
+      description: 任何你觉得值得说的。


### PR DESCRIPTION
现在的issue太乱了，新增加的模板，让接下来更有条理。

另外，可以的话，建议作者开启 github 的 discussion 板块。 