### PR TITLE
增加本地频道模块

### DIFF
--- a/app/src/main/java/com/lizongying/mytv/MainActivity.kt
+++ b/app/src/main/java/com/lizongying/mytv/MainActivity.kt
@@ -47,6 +47,7 @@ class MainActivity : FragmentActivity() {
     private var channelReversal = false
     private var channelNum = true
     private var bootStartup = true
+    private var selectedProvince = "湖南"
 
     private var versionName = ""
 
@@ -84,9 +85,10 @@ class MainActivity : FragmentActivity() {
         channelReversal = sharedPref.getBoolean(CHANNEL_REVERSAL, channelReversal)
         channelNum = sharedPref.getBoolean(CHANNEL_NUM, channelNum)
         bootStartup = sharedPref.getBoolean(BOOT_STARTUP, bootStartup)
+        selectedProvince = sharedPref.getString(SELECTED_PROVINCE, selectedProvince)
 
         versionName = getPackageInfo().versionName
-        settingFragment = SettingFragment(versionName, channelReversal, channelNum, bootStartup)
+        settingFragment = SettingFragment(versionName, channelReversal, channelNum, bootStartup, selectedProvince)
     }
 
     fun showInfoFragment(tvViewModel: TVViewModel) {
@@ -241,10 +243,18 @@ class MainActivity : FragmentActivity() {
 
     fun saveBootStartup(bootStartup: Boolean) {
         with(sharedPref.edit()) {
-            putBoolean(CHANNEL_NUM, channelNum)
+            putBoolean(BOOT_STARTUP, bootStartup)
             apply()
         }
         this.bootStartup = bootStartup
+    }
+
+    fun saveSelectedProvince(selectedProvince: Sring) {
+        with(sharedPref.edit()) {
+            putString(SELECTED_PROVINCE, selectedProvince)
+            apply()
+        }
+        this.selectedProvince = selectedProvince
     }
 
     private fun showSetting() {
@@ -536,5 +546,6 @@ class MainActivity : FragmentActivity() {
         private const val CHANNEL_REVERSAL = "channel_reversal"
         private const val CHANNEL_NUM = "channel_num"
         const val BOOT_STARTUP = "boot_startup"
+        const val SELECTED_PROVINCE = "selected_province"
     }
 }

--- a/app/src/main/java/com/lizongying/mytv/SettingFragment.kt
+++ b/app/src/main/java/com/lizongying/mytv/SettingFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import androidx.fragment.app.DialogFragment
 import com.lizongying.mytv.databinding.DialogBinding
 
@@ -12,6 +14,7 @@ class SettingFragment(private val versionName: String,
                       private val channelReversal: Boolean,
                       private val channelNum: Boolean,
                       private val bootStartup: Boolean,
+                      private val selectedProvince: String,
     ) :
     DialogFragment() {
 
@@ -50,12 +53,37 @@ class SettingFragment(private val versionName: String,
             (activity as MainActivity).saveBootStartup(isChecked)
         }
 
+        // 设置省份Spinner
+        val provinceSpinner = binding.provinceSpinner
+        val provinces = arrayOf("北京", "上海", "天津", "重庆", "河北", "山西", "内蒙古", "辽宁", "吉林", "黑龙江", "江苏", "浙江", "安徽", "福建", "江西", "山东", "河南", "湖北", "湖南", "广东", "广西", "海南", "四川", "贵州", "云南", "西藏", "陕西", "甘肃", "青海", "宁夏", "新疆", "台湾", "香港", "澳门")
+        val adapter = ArrayAdapter<String>(requireContext(), android.R.layout.simple_spinner_dropdown_item, provinces)
+        provinceSpinner.adapter = adapter
+
+        // 设置默认选择为“湖南”
+        val defaultIndex = provinces.indexOf("湖南")
+        if (defaultIndex != -1) {
+            provinceSpinner.setSelection(defaultIndex)
+        }
+
+        // 设置Spinner的监听器
+        provinceSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                selectedProvince = provinces[position]
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) {
+                selectedProvince = null
+            }
+        }
+
         return binding.root
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+        // 取消Spinner的监听器(看是否需要吧)
+        binding.provinceSpinner.onItemSelectedListener = null
     }
 
     companion object {

--- a/app/src/main/java/com/lizongying/mytv/TVList.kt
+++ b/app/src/main/java/com/lizongying/mytv/TVList.kt
@@ -990,8 +990,19 @@ object TVList {
                 //获取本地频道
                 ChannelUtils.getLocalChannel(context)
             }
+            //获取定义的省份数据
+            val sp = context.getSharedPreferences("MainActivity", Context.MODE_PRIVATE)
             //按频道分类
             for (tv in tvList) {
+
+                // 如果是本地频道，则判断频道名称是否包含设置的省份，默认设置为湖南省，可遥控呼出菜单修改
+                if ( tv.channel == "本地频道" ) {
+                    if ( !tv.title.contains(sp.getString(MainActivity.SELECTED_PROVINCE, "湖南")) ) {
+                        Log.i("TVList", "跳过频道：${tv.title}")
+                        continue;
+                    }
+                }
+
                 val key = tv.channel
                 if (channelTVMap.containsKey(key)) {
                     val list = channelTVMap[key]!!

--- a/app/src/main/res/layout/dialog.xml
+++ b/app/src/main/res/layout/dialog.xml
@@ -46,6 +46,11 @@
                 android:layout_marginTop="10dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
+            <Spinner
+                android:id="@+id/provinceSpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:prompt="@string/please_select_province"/>
         </LinearLayout>
         <ImageView
             android:layout_width="300dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="title_channel_reversal">换台反转</string>
     <string name="title_channel_num">数字选台</string>
     <string name="title_boot_startup">开机自启</string>
+    <string name="please_select_province">请选择您的省份</string>
 </resources>


### PR DESCRIPTION
增加本地频道模块，例如湖南都市、 湖南经视、湖南卡通等频道，可通过遥控菜单键呼出设置省份，默认为湖南。
频道列表中初始化进行筛选，仅显示包含省份名的频道。
至于频道相关信息，打算到远程地址[channels.json](https://github.com/LeGend-wLw/my-tv-json-utils/blob/main/channels.json)更新。

以上修改全靠臆想，没有完整的源码和环境，仅做参考。![02099AB3](https://github.com/lizongying/my-tv/assets/15410727/e24fb1dd-b572-4dc0-bc64-2af4a6915da8)
