### PR TITLE
修复远程服务地址

### DIFF
--- a/app/src/main/res/values/server.xml
+++ b/app/src/main/res/values/server.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="local_channel_version">1</integer>
-    <string name="server_version_url">https://cdn.jsdelivr.net/gh/LeGend-wLw/my-tv-json-utils@main/version.txt</string>
-    <string name="server_url">https://cdn.jsdelivr.net/gh/LeGend-wLw/my-tv-json-utils@raw/main/channels.json</string>
+    <string name="server_version_url">https://fastly.jsdelivr.net/gh/LeGend-wLw/my-tv-json-utils@main/version.txt</string>
+    <string name="server_url">https://fastly.jsdelivr.net/gh/LeGend-wLw/my-tv-json-utils@main/channels.json</string>
 </resources>


### PR DESCRIPTION
- 原远程服务CDN地址`https://cdn.jsdelivr.net/gh/LeGend-wLw/my-tv-json-utils@raw/main/channels.json`有误已修复。

- 另外GitHub镜像服务`fastly.jsdelivr.net`要比`cdn.jsdelivr.net`快一些，对比如图，已修改。
![20240214161134](https://github.com/lizongying/my-tv/assets/15410727/f0e10372-2e1d-4b3c-87d6-5a8dfb1399c1)
