### PR TITLE
创建 SP 工具类，管理所有（除 ChannelUtils 以外）用户偏好设置

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,5 +38,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </receiver>
+        <provider
+            android:name=".InitializerProvider"
+            android:authorities="${applicationId}.InitializerProvider"
+            android:exported="false"
+            android:initOrder="900" />
     </application>
 </manifest>

--- a/app/src/main/java/com/lizongying/mytv/BootReceiver.kt
+++ b/app/src/main/java/com/lizongying/mytv/BootReceiver.kt
@@ -7,8 +7,7 @@ import android.content.Intent
 class BootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        val sp = context.getSharedPreferences("MainActivity", Context.MODE_PRIVATE)
-        if (sp.getBoolean(MainActivity.BOOT_STARTUP, true)) {
+        if (SP.bootStartup) {
             context.startActivity(
                 Intent(context, MainActivity::class.java)
                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/com/lizongying/mytv/InitializerProvider.kt
+++ b/app/src/main/java/com/lizongying/mytv/InitializerProvider.kt
@@ -1,0 +1,39 @@
+package com.lizongying.mytv
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.net.Uri
+
+internal class InitializerProvider : ContentProvider() {
+
+    // Happens before Application#onCreate.It's fine to init something here
+    override fun onCreate(): Boolean {
+        SP.init(context!!)
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ) = unsupported()
+
+    override fun getType(uri: Uri) = unsupported()
+
+    override fun insert(uri: Uri, values: ContentValues?) = unsupported()
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?) =
+        unsupported()
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ) = unsupported()
+
+    private fun unsupported(errorMessage: String? = null): Nothing =
+        throw UnsupportedOperationException(errorMessage)
+}

--- a/app/src/main/java/com/lizongying/mytv/MainActivity.kt
+++ b/app/src/main/java/com/lizongying/mytv/MainActivity.kt
@@ -1,7 +1,5 @@
 package com.lizongying.mytv
 
-import android.content.Context
-import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.Signature
@@ -43,11 +41,6 @@ class MainActivity : FragmentActivity() {
     private val delayHideMain: Long = 5000
     private val delayHideSetting: Long = 10000
 
-    lateinit var sharedPref: SharedPreferences
-    private var channelReversal = false
-    private var channelNum = true
-    private var bootStartup = true
-
     private var versionName = ""
 
     init {
@@ -79,19 +72,13 @@ class MainActivity : FragmentActivity() {
                 .commit()
         }
         gestureDetector = GestureDetector(this, GestureListener())
-
-        sharedPref = getPreferences(Context.MODE_PRIVATE)
-        channelReversal = sharedPref.getBoolean(CHANNEL_REVERSAL, channelReversal)
-        channelNum = sharedPref.getBoolean(CHANNEL_NUM, channelNum)
-        bootStartup = sharedPref.getBoolean(BOOT_STARTUP, bootStartup)
-
         versionName = getPackageInfo().versionName
-        settingFragment = SettingFragment(versionName, channelReversal, channelNum, bootStartup)
+        settingFragment = SettingFragment(versionName, SP.channelReversal, SP.channelNum, SP.bootStartup)
     }
 
     fun showInfoFragment(tvViewModel: TVViewModel) {
         infoFragment.show(tvViewModel)
-        if (channelNum) {
+        if (SP.channelNum) {
             channelFragment.show(tvViewModel)
         }
     }
@@ -105,7 +92,7 @@ class MainActivity : FragmentActivity() {
             return
         }
 
-        if (channelNum) {
+        if (SP.channelNum) {
             channelFragment.show(channel)
         }
     }
@@ -223,30 +210,6 @@ class MainActivity : FragmentActivity() {
         }
     }
 
-    fun saveChannelReversal(channelReversal: Boolean) {
-        with(sharedPref.edit()) {
-            putBoolean(CHANNEL_REVERSAL, channelReversal)
-            apply()
-        }
-        this.channelReversal = channelReversal
-    }
-
-    fun saveChannelNum(channelNum: Boolean) {
-        with(sharedPref.edit()) {
-            putBoolean(CHANNEL_NUM, channelNum)
-            apply()
-        }
-        this.channelNum = channelNum
-    }
-
-    fun saveBootStartup(bootStartup: Boolean) {
-        with(sharedPref.edit()) {
-            putBoolean(BOOT_STARTUP, bootStartup)
-            apply()
-        }
-        this.bootStartup = bootStartup
-    }
-
     private fun showSetting() {
         if (!mainFragment.isHidden) {
             return
@@ -271,7 +234,7 @@ class MainActivity : FragmentActivity() {
 
     private fun channelUp() {
         if (mainFragment.isHidden) {
-            if (channelReversal) {
+            if (SP.channelReversal) {
                 next()
                 return
             }
@@ -288,7 +251,7 @@ class MainActivity : FragmentActivity() {
 
     private fun channelDown() {
         if (mainFragment.isHidden) {
-            if (channelReversal) {
+            if (SP.channelReversal) {
                 prev()
                 return
             }
@@ -520,7 +483,7 @@ class MainActivity : FragmentActivity() {
     override fun onResume() {
         Log.i(TAG, "onResume")
         super.onResume()
-        if (!mainFragment.isHidden){
+        if (!mainFragment.isHidden) {
             handler.postDelayed(hideMain, delayHideMain)
         }
     }
@@ -531,10 +494,7 @@ class MainActivity : FragmentActivity() {
         handler.removeCallbacks(hideMain)
     }
 
-    companion object {
-        private const val TAG = "MainActivity"
-        private const val CHANNEL_REVERSAL = "channel_reversal"
-        private const val CHANNEL_NUM = "channel_num"
-        const val BOOT_STARTUP = "boot_startup"
+    private companion object {
+        const val TAG = "MainActivity"
     }
 }

--- a/app/src/main/java/com/lizongying/mytv/MainFragment.kt
+++ b/app/src/main/java/com/lizongying/mytv/MainFragment.kt
@@ -1,6 +1,5 @@
 package com.lizongying.mytv
 
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -34,8 +33,6 @@ class MainFragment : BrowseSupportFragment() {
 
     var tvListViewModel = TVListViewModel()
 
-    private lateinit var sharedPref: SharedPreferences
-
     private var lastVideoUrl = ""
 
     private val handler = Handler(Looper.getMainLooper())
@@ -58,7 +55,6 @@ class MainFragment : BrowseSupportFragment() {
         super.onActivityCreated(savedInstanceState)
 
         activity?.let { request.initYSP(it) }
-        sharedPref = (activity as? MainActivity)?.sharedPref!!
 
         loadRows()
 
@@ -156,7 +152,7 @@ class MainFragment : BrowseSupportFragment() {
 
         adapter = rowsAdapter
 
-        itemPosition = sharedPref.getInt(POSITION, 0)
+        itemPosition = SP.itemPosition
         if (itemPosition >= tvListViewModel.size()) {
             itemPosition = 0
         }
@@ -322,11 +318,8 @@ class MainFragment : BrowseSupportFragment() {
     override fun onStop() {
         Log.i(TAG, "onStop")
         super.onStop()
-        with(sharedPref.edit()) {
-            putInt(POSITION, itemPosition)
-            apply()
-        }
-        Log.i(TAG, "$POSITION saved")
+        SP.itemPosition = itemPosition
+        Log.i(TAG, "position saved")
     }
 
     override fun onDestroy() {
@@ -337,6 +330,5 @@ class MainFragment : BrowseSupportFragment() {
 
     companion object {
         private const val TAG = "MainFragment"
-        private const val POSITION = "position"
     }
 }

--- a/app/src/main/java/com/lizongying/mytv/SP.kt
+++ b/app/src/main/java/com/lizongying/mytv/SP.kt
@@ -1,0 +1,49 @@
+package com.lizongying.mytv
+
+import android.content.Context
+import android.content.SharedPreferences
+
+object SP {
+    // Name of the sp file TODO Should use a meaningful name and do migrations
+    private const val SP_FILE_NAME = "MainActivity"
+    // if Change channel with up and down in reversed order or not
+    private const val KEY_CHANNEL_REVERSAL = "channel_reversal"
+    // If use channel num to select channel or not
+    private const val KEY_CHANNEL_NUM = "channel_num"
+    // If start app on device boot or not
+    private const val KEY_BOOT_STARTUP = "boot_startup"
+    // Position in list of the selected channel item
+    private const val KEY_POSITION = "position"
+    // guid
+    private const val KEY_GUID = "guid"
+    // guid
+    private lateinit var sp: SharedPreferences
+
+    /**
+     * The method must be invoked as early as possible(At least before using the keys)
+     */
+    fun init(context: Context) {
+        sp = context.getSharedPreferences(SP_FILE_NAME, Context.MODE_PRIVATE)
+    }
+
+    var channelReversal: Boolean
+        get() = sp.getBoolean(KEY_CHANNEL_REVERSAL, false)
+        set(value) = sp.edit().putBoolean(KEY_CHANNEL_REVERSAL, value).apply()
+
+    var channelNum: Boolean
+        get() = sp.getBoolean(KEY_CHANNEL_NUM, true)
+        set(value) = sp.edit().putBoolean(KEY_CHANNEL_NUM, value).apply()
+
+    var bootStartup: Boolean
+        // TODO It‘s more friendly to change the default value to false
+        get() = sp.getBoolean(KEY_BOOT_STARTUP, true)
+        set(value) = sp.edit().putBoolean(KEY_BOOT_STARTUP, value).apply()
+
+    var itemPosition: Int
+        get() = sp.getInt(KEY_POSITION, 0)
+        set(value) = sp.edit().putInt(KEY_POSITION, value).apply()
+
+    var guid: String
+        get() = sp.getString(KEY_GUID, "")  ?: ""
+        set(value) = sp.edit().putString(KEY_GUID, value).apply()
+}

--- a/app/src/main/java/com/lizongying/mytv/SettingFragment.kt
+++ b/app/src/main/java/com/lizongying/mytv/SettingFragment.kt
@@ -35,19 +35,19 @@ class SettingFragment(private val versionName: String,
         val switchChannelReversal = _binding?.switchChannelReversal
         switchChannelReversal?.isChecked = channelReversal
         switchChannelReversal?.setOnCheckedChangeListener { _, isChecked ->
-            (activity as MainActivity).saveChannelReversal(isChecked)
+            SP.channelReversal = isChecked
         }
 
         val switchChannelNum = _binding?.switchChannelNum
         switchChannelNum?.isChecked = channelNum
         switchChannelNum?.setOnCheckedChangeListener { _, isChecked ->
-            (activity as MainActivity).saveChannelNum(isChecked)
+            SP.channelNum = isChecked
         }
 
         val switchBootStartup = _binding?.switchBootStartup
         switchBootStartup?.isChecked = bootStartup
         switchBootStartup?.setOnCheckedChangeListener { _, isChecked ->
-            (activity as MainActivity).saveBootStartup(isChecked)
+            SP.bootStartup = isChecked
         }
 
         return binding.root

--- a/app/src/main/java/com/lizongying/mytv/api/YSP.kt
+++ b/app/src/main/java/com/lizongying/mytv/api/YSP.kt
@@ -1,9 +1,9 @@
 package com.lizongying.mytv.api
 
 import android.content.Context
-import android.content.SharedPreferences
 import com.lizongying.mytv.Encryptor
 import com.lizongying.mytv.MainActivity
+import com.lizongying.mytv.SP
 import com.lizongying.mytv.Utils.getDateTimestamp
 import com.lizongying.mytv.models.TVViewModel
 import kotlin.math.floor
@@ -51,14 +51,11 @@ class YSP(var context: Context) {
     private var signature = ""
 
     private var encryptor: Encryptor? = null
-    private lateinit var sharedPref: SharedPreferences
 
     init {
         if (context is MainActivity) {
             encryptor = Encryptor()
             encryptor!!.init(context)
-
-            sharedPref = (context as MainActivity).sharedPref
         }
 
         guid = getGuid()
@@ -94,23 +91,17 @@ class YSP(var context: Context) {
     }
 
     fun getGuid(): String {
-        var guid = sharedPref.getString("guid", "")
-        if (guid == null || guid.length < 18) {
+        var guid = SP.guid
+        if (guid.length < 18) {
             guid = generateGuid()
-            with(sharedPref.edit()) {
-                putString("guid", guid)
-                apply()
-            }
+            SP.guid = guid
         }
         return guid
     }
 
     private fun newGuid(): String {
         guid = generateGuid()
-        with(sharedPref.edit()) {
-            putString("guid", guid)
-            apply()
-        }
+        SP.guid = guid
         return guid
     }
 


### PR DESCRIPTION
- 另外新增了 Initializer 类，直接目的是初始化 SP 工具类，不过也可用于其他需要尽快进行初始化的组件。
- 使用专门的 SP 工具类能够让业务代码更加简洁，同时有利于简化对 SP 的维护工作。