### PR TITLE
Update MainActivity.kt

### DIFF
--- a/app/src/main/java/com/lizongying/mytv/MainActivity.kt
+++ b/app/src/main/java/com/lizongying/mytv/MainActivity.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-
+import kotlin.system.exitProcess
 
 class MainActivity : FragmentActivity(), Request.RequestListener {
 
@@ -340,7 +340,7 @@ class MainActivity : FragmentActivity(), Request.RequestListener {
         }
 
         if (doubleBackToExitPressedOnce) {
-            super.onBackPressed()
+             exitProcess(0)
             return
         }
 


### PR DESCRIPTION
在Google TV 上apk back 返回会进入到后台，电视盒子进入休眠，不会被kill,导致再次打开黑屏，修改为彻底退出