### PR TITLE
fix：修复无法升级，无法自动安装apk

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 

--- a/app/src/main/java/com/lizongying/mytv/SettingFragment.kt
+++ b/app/src/main/java/com/lizongying/mytv/SettingFragment.kt
@@ -51,7 +51,6 @@ class SettingFragment : DialogFragment() {
         val context = requireContext() // It‘s safe to get context here.
         _binding = SettingBinding.inflate(inflater, container, false)
         binding.versionName.text = "当前版本: v${context.appVersionName}"
-        binding.version.text = "https://github.com/lizongying/my-tv"
 
         binding.switchChannelReversal.run {
             isChecked = SP.channelReversal
@@ -90,6 +89,26 @@ class SettingFragment : DialogFragment() {
             setOnCheckedChangeListener { _, isChecked ->
                 SP.grid = isChecked
                 (activity as MainActivity).settingDelayHide()
+            }
+        }
+
+        binding.switchUpdateUrl.run {
+            isChecked = SP.grid
+            setOnCheckedChangeListener { _, isChecked ->
+                SP.grid = isChecked
+                (activity as MainActivity).settingDelayHide()
+
+                if (true == isChecked) {
+                    binding.version.text = "https://gitee.com/lizongying/my-tv"
+                } else {
+                    binding.version.text = "https://github.com/lizongying/my-tv"
+                }
+            }
+
+            if (true == isChecked) {
+                binding.version.text = "https://gitee.com/lizongying/my-tv"
+            } else {
+                binding.version.text = "https://github.com/lizongying/my-tv"
             }
         }
 
@@ -152,6 +171,9 @@ class SettingFragment : DialogFragment() {
         binding.switchGrid.textSize = textSize
         binding.switchGrid.layoutParams = layoutParamsChannelSwitch
 
+        binding.switchUpdateUrl.textSize = textSize
+        binding.switchUpdateUrl.layoutParams = layoutParamsChannelSwitch
+
         binding.appreciate.layoutParams.width =
             application.px2Px(binding.appreciate.layoutParams.width)
 
@@ -165,40 +187,41 @@ class SettingFragment : DialogFragment() {
     }
 
     private fun requestInstallPermissions() {
-        val context = requireContext()
-        val permissionsList: MutableList<String> = ArrayList()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !context.packageManager.canRequestPackageInstalls()) {
-            permissionsList.add(Manifest.permission.REQUEST_INSTALL_PACKAGES)
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            permissionsList.add(Manifest.permission.READ_EXTERNAL_STORAGE)
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            permissionsList.add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-        }
-
-        if (permissionsList.isNotEmpty()) {
-            ActivityCompat.requestPermissions(
-                requireActivity(),
-                permissionsList.toTypedArray<String>(),
-                PERMISSIONS_REQUEST_CODE
-            )
-        } else {
-            updateManager.checkAndUpdate()
-        }
+//        val context = requireContext()
+//        val permissionsList = mutableListOf<String>()
+//
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !context.packageManager.canRequestPackageInstalls()) {
+//            permissionsList.add(Manifest.permission.REQUEST_INSTALL_PACKAGES)
+//        }
+//
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+//            ContextCompat.checkSelfPermission(
+//                context,
+//                Manifest.permission.READ_EXTERNAL_STORAGE
+//            ) != PackageManager.PERMISSION_GRANTED
+//        ) {
+//            permissionsList.add(Manifest.permission.READ_EXTERNAL_STORAGE)
+//        }
+//
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+//            ContextCompat.checkSelfPermission(
+//                context,
+//                Manifest.permission.WRITE_EXTERNAL_STORAGE
+//            ) != PackageManager.PERMISSION_GRANTED
+//        ) {
+//            permissionsList.add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+//        }
+//
+//        if (permissionsList.isNotEmpty()) {
+//            ActivityCompat.requestPermissions(
+//                requireActivity(),
+//                permissionsList.toTypedArray(),
+//                PERMISSIONS_REQUEST_CODE
+//            )
+//        } else {
+//            updateManager.checkAndUpdate()
+//        }
+        updateManager.checkAndUpdate()
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/java/com/lizongying/mytv/UpdateWorker.kt
+++ b/app/src/main/java/com/lizongying/mytv/UpdateWorker.kt
@@ -123,16 +123,13 @@ class UpdateWorker(context: Context, params: WorkerParameters) : CoroutineWorker
 
         if (apkFile.exists()) {
             val apkUri: Uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                FileProvider.getUriForFile(context, context.packageName + ".fileprovider", apkFile)
-                    .apply {
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION
-                    }
+                FileProvider.getUriForFile(context, "${context.packageName}.provider", apkFile)
             } else {
                 Uri.parse("file://${apkFile.absolutePath}")
-//                Uri.fromFile(apkFile)
             }
-//            val apkUri = Uri.parse("file://$apkFile")
+
             Log.i(TAG, "apkUri $apkUri")
+
             val installIntent = Intent(Intent.ACTION_VIEW).apply {
                 setDataAndType(apkUri, "application/vnd.android.package-archive")
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/res/layout/setting.xml
+++ b/app/src/main/res/layout/setting.xml
@@ -108,6 +108,13 @@
                 android:layout_marginTop="5dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
+            <Switch
+                android:id="@+id/switch_update_url"
+                android:text="@string/update_url"
+                android:textSize="14sp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp" />
         </LinearLayout>
     </ScrollView>
     <ImageView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="title_boot_startup">开机自启</string>
     <string name="title_grid">频道列表采用网格样式</string>
     <string name="title_time">显示时间</string>
+    <string name="update_url">更新地址，关闭全球，打开中国</string>
     <string name="clear">恢复默认</string>
     <string name="exit">退出应用</string>
 </resources>


### PR DESCRIPTION
1、支持更新地址选择全球github、中国gitee
2、取消升级的动态权限申请，很多设备上申请失败，在AndroidManifest.xml中增加存储读权限
3、修复升级自动安装apk

